### PR TITLE
Fix package download

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "2.0.0",
     "summary": "A reliable way to format dates with Elm",
-    "repository": "https://github.com/ryannhg/elm-date-format.git",
+    "repository": "https://github.com/RyanNHG/elm-date-format.git",
     "license": "BSD3",
     "source-directories": [
         "./src"


### PR DESCRIPTION
I _think_ this should fix #2. The repository field is case sensitive I believe.

I think you'll need to run elm publish again. That should create a new package on the package website. You might want to put a deprecation notice in the version with all lower case.